### PR TITLE
Issue #7 Bug fix to display privacy details text on privacy page 

### DIFF
--- a/mvc-agile-process/Views/Home/Privacy.cshtml
+++ b/mvc-agile-process/Views/Home/Privacy.cshtml
@@ -3,4 +3,57 @@
 }
 <h1>@ViewData["Title"]</h1>
 
-<p>Use this page to detail your site's privacy policy.</p>
+<section>
+    <h2>Your Privacy Matters to Us</h2>
+    <p>
+        We value your privacy and are committed to protecting your personal information. 
+        This Privacy Policy explains how we collect, use, and safeguard your data when you
+        use our Movie App to create, view, edit, or delete movie information.
+    </p>
+</section>
+
+<section>
+    <h2>Information We Collect</h2>
+    <ul>
+        <li><strong>User Information</strong>: such as your username or email, collected when you create an account or log in.</li>
+        <li><strong>Movie Data</strong>: movie titles, descriptions, genres, release dates, and ratings that you create or edit within the app.</li>
+        <li><strong>Usage Data</strong>: such as the pages you visit, the movies you interact with, and your activity history, used to enhance your app experience.</li>
+        <li><strong>Technical Data</strong>: like your IP address, browser type, and device information, collected automatically for performance and security monitoring.</li>
+    </ul>
+</section>
+
+<section>
+    <h2>How We Use Your Information</h2>
+    <ul>
+        <li>To allow you to create, edit, and manage your movie entries.</li>
+        <li>To personalize your experience within the app.</li>
+        <li>To monitor and improve app functionality and performance.</li>
+        <li>To provide support and respond to inquiries if needed.</li>
+    </ul>
+</section>
+
+<section>
+    <h2>Sharing of Information</h2>
+    <p>
+        We do not sell your personal information. Your data is only shared with trusted third-party
+        tools when necessary to operate or improve our app, and those tools are required to maintain
+        confidentiality.
+    </p>
+</section>
+
+<section>
+    <h2>Data Security</h2>
+    <p>
+        We implement appropriate technical and organizational security measures to protect your data
+        from unauthorized access, alteration, or loss.
+    </p>
+</section>
+
+<section>
+    <h2>Your Rights</h2>
+    <ul>
+        <li>You can access and update your personal information at any time.</li>
+        <li>You may request deletion of your account and associated data.</li>
+        <li>You can contact us to understand more about how your data is used.</li>
+    </ul>
+</section>


### PR DESCRIPTION
This PR merges branch [**bugfix/issue-7-privacy-page-details**] to branch [**master**].

- Resolved an issue where the privacy details content was not being rendered on the privacy page.
- Updated the Privacy.cshtml file to include the correct static text content.

Closes #7 